### PR TITLE
some railings rework

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -99,10 +99,10 @@
 	if (!can_climb(user))
 		return
 
-	usr.visible_message("<span class='warning'>\The [user] starts climbing onto \the [src]!</span>")
+	usr.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
 	climbers |= user
 
-	if(!do_after(user,(issmall(user) ? 30 : 50), src))
+	if(!do_after(user,(issmall(user) ? 20 : 34)))
 		climbers -= user
 		return
 
@@ -113,7 +113,7 @@
 	usr.forceMove(get_turf(src))
 
 	if (get_turf(user) == get_turf(src))
-		usr.visible_message("<span class='warning'>\The [user] climbs onto \the [src]!</span>")
+		usr.visible_message("<span class='warning'>[user] climbs onto \the [src]!</span>")
 	climbers -= user
 
 /obj/structure/proc/structure_shaken()

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -1,14 +1,15 @@
 /obj/structure/railing
 	name = "railing"
-	desc = "A railing."
+	desc = "A standart steel railing. Prevents from human stupidity."
 	icon = 'icons/obj/railing.dmi'
 	density = 1
+	throwpass = 1
+	climbable = 1
 	layer = 3.2//Just above doors
 	//pressure_resistance = 4*ONE_ATMOSPHERE
 	anchored = 1
 	flags = ON_BORDER
 	icon_state = "railing0"
-	//layer = 4.1
 	var/broken = 0
 	var/health=30
 	var/maxhealth=30
@@ -16,10 +17,21 @@
 	//var/RightSide = list(0,0,0)
 	var/check = 0
 
-obj/structure/railing/New()
+/obj/structure/railing/New()
+	..()
+	if(climbable)
+		verbs += /obj/structure/proc/climb_on
 	if(src.anchored)
 		spawn(5)
 			update_icon(0)
+
+/obj/structure/railing/Destroy()
+	anchored = null
+	flags = null
+	broken = 1
+	for(var/obj/structure/railing/R in oview(src, 1))
+		R.update_icon()
+	..()
 
 /obj/structure/railing/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(!mover)
@@ -32,8 +44,26 @@ obj/structure/railing/New()
 	else
 		return 1
 //32 и 4 - в той же клетке
-//
-//
+
+/obj/structure/railing/examine(mob/user)
+	. = ..()
+	if(health < maxhealth)
+		switch(health / maxhealth)
+			if(0.0 to 0.5)
+				user << "<span class='warning'>It looks severely damaged!</span>"
+			if(0.25 to 0.5)
+				user << "<span class='warning'>It looks damaged!</span>"
+			if(0.5 to 1.0)
+				user << "<span class='notice'>It has a few scrapes and dents.</span>"
+
+/obj/structure/railing/proc/take_damage(amount)
+	health -= amount
+	if(health <= 0)
+		visible_message("<span class='warning'>\The [src] breaks down!</span>")
+		playsound(loc, 'sound/effects/grillehit.ogg', 50, 1)
+		new /obj/item/stack/rods(get_turf(usr))
+		qdel(src)
+
 /obj/structure/railing/proc/NeighborsCheck(var/UpdateNeighbors = 1)
 	check = 0
 	//if (!anchored) return
@@ -131,8 +161,8 @@ obj/structure/railing/New()
 		return 0
 
 	set_dir(turn(dir, 90))
+	update_icon()
 	return
-
 
 /obj/structure/railing/verb/revrotate()
 	set name = "Rotate Railing Clockwise"
@@ -147,6 +177,28 @@ obj/structure/railing/New()
 		return 0
 
 	set_dir(turn(dir, -90))
+	update_icon()
+	return
+
+/obj/structure/railing/verb/flip() // This will help push railing to remote places, such as open space turfs
+	set name = "Flip Railing"
+	set category = "Object"
+	set src in oview(1)
+
+	if(usr.incapacitated())
+		return 0
+
+	if(anchored)
+		usr << "It is fastened to the floor therefore you can't flip it!"
+		return 0
+
+	if(get_step(src, src.dir) == "turf/simulated/wall/")
+		usr << "You can't flip the [src] into the wall"
+		return 0
+
+	src.loc = get_step(src, src.dir)
+	set_dir(turn(dir, 180))
+	update_icon()
 	return
 
 /obj/structure/railing/CheckExit(atom/movable/O as mob|obj, target as turf)
@@ -156,42 +208,36 @@ obj/structure/railing/New()
 		return 0
 	return 1
 
+/obj/structure/railing/attackby(obj/item/W as obj, mob/user as mob)
+	// Dismantle
+	if(istype(W, /obj/item/weapon/wrench) && !anchored)
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		if(do_after(user, 20, src))
+			user.visible_message("<span class='notice'>\The [user] dismantles \the [src].</span>", "<span class='notice'>You dismantle \the [src].</span>")
+			new /obj/item/stack/material/steel(get_turf(usr))
+			new /obj/item/stack/material/steel(get_turf(usr))
+			qdel(src)
+			return
 
-/obj/structure/railing/attackby(obj/item/W as obj, mob/user as mob) // Это спижено у стола данного билда
-	//if (!W) return
+	// Repair
+	if(health < maxhealth && istype(W, /obj/item/weapon/weldingtool))
+		var/obj/item/weapon/weldingtool/F = W
+		if(F.welding)
+			playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
+			if(do_after(user, 20, src))
+				user.visible_message("<span class='notice'>\The [user] repairs some damage to \the [src].</span>", "<span class='notice'>You repair some damage to \the [src].</span>")
+				health = min(health+(maxhealth/5), maxhealth)//max(health+(maxhealth/5), maxhealth) // 20% repair per application
+				return
 
-	if(istype(W, /obj/item/weapon/wrench) && !anchored)//разборка
-		visible_message("<span class='notice'>[user] dismantles \the [src].</span>")
-		playsound(loc, 'sound/items/Ratchet.ogg', 75, 1)
-		var/obj/item/stack/material/mats = new /material/steel(loc)
-		if (!broken && (health >= (maxhealth/2)))
-			mats.amount = 2
-		else
-			mats.amount = 1
-		qdel(src)
-		return
-
-	if(istype(W, /obj/item/weapon/weldingtool)) // ремонт
-		if (health < maxhealth)
-			var/obj/item/weapon/weldingtool/WT = W
-			if(!WT.remove_fuel(0,user))
-				if(!WT.isOn())
-					return
-				else
-					user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
-					return
-			health = maxhealth
-			visible_message("<span class='notice'>[user] repair \the [src].</span>")
-		else
-			user << "<span class='notice'>[src] look undamaged</span>"
-		return
-
-	if(istype(W, /obj/item/weapon/screwdriver))//установка
-		anchored = !anchored
-		update_icon()
+	// Install
+	if(istype(W, /obj/item/weapon/screwdriver))
+		user.visible_message(anchored ? "<span class='notice'>\The [user] begins unscrew \the [src].</span>" : "<span class='notice'>\The [user] begins fasten \the [src].</span>" )
 		playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
-		user << (anchored ? "<span class='notice'>You have fastened the [src] to the floor.</span>" : "<span class='notice'>You have unfastened the [src] from the floor.</span>")
-		return
+		if(do_after(user, 10, src))
+			user << (anchored ? "<span class='notice'>You have unfastened \the [src] from the floor.</span>" : "<span class='notice'>You have fastened \the [src] to the floor.</span>")
+			anchored = !anchored
+			update_icon()
+			return
 
 	// Handle harm intent grabbing/tabling.
 	if(istype(W, /obj/item/weapon/grab) && get_dist(src,user)<2)
@@ -206,47 +252,28 @@ obj/structure/railing/New()
 				if(user.a_intent == I_HURT)
 					if (prob(15))	M.Weaken(5)
 					M.apply_damage(8,def_zone = "head")
+					take_damage(8)
 					visible_message("<span class='danger'>[G.assailant] slams [G.affecting]'s face against \the [src]!</span>")
-					playsound(loc, 'sound/weapons/tablehit1.ogg', 50, 1)
-					/*var/list/L = take_damage(rand(1,5))
-					// Shards. Extra damage, plus potentially the fact YOU LITERALLY HAVE A PIECE OF GLASS/METAL/WHATEVER IN YOUR FACE
-					for(var/obj/item/weapon/material/shard/S in L)
-						if(prob(50))
-							M.visible_message("<span class='danger'>\The [S] slices [M]'s face messily!</span>",
-							                   "<span class='danger'>\The [S] slices your face messily!</span>")
-							M.apply_damage(10, def_zone = "head")
-							if(prob(2))
-								M.embed(S, def_zone = "head")*/
+					playsound(loc, 'sound/effects/grillehit.ogg', 50, 1)
 				else
 					user << "<span class='danger'>You need a better grip to do that!</span>"
 					return
 			else
-				G.affecting.loc = src.loc
+				if (get_turf(G.affecting) == get_turf(src))
+					G.affecting.forceMove(get_step(src, src.dir))
+				else
+					G.affecting.forceMove(get_turf(src))
 				G.affecting.Weaken(5)
-				visible_message("<span class='danger'>[G.assailant] puts [G.affecting] on \the [src].</span>")
+				visible_message("<span class='danger'>[G.assailant] throws [G.affecting] over \the [src]!</span>")
 			qdel(W)
 			return
 
-	// Handle dismantling or placing things on the table from here on.
-	if(isrobot(user))
-		return
+	else
+		user.visible_message("<span class='danger'>\The [src] has been hit by [user] with \the [W].</span>")
+		playsound(loc, 'sound/effects/grillehit.ogg', 50, 1)
+		take_damage(W.force)
 
-	if(W.loc != user) // This should stop mounted modules ending up outside the module.
-		return
-
-	if(istype(W, /obj/item/weapon/melee/energy/blade))
-		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-		spark_system.set_up(5, 0, src.loc)
-		spark_system.start()
-		playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
-		playsound(src.loc, "sparks", 50, 1)
-		user.visible_message("<span class='danger'>\The [src] was sliced apart by [user]!</span>")
-		//break_to_parts()
-		return
-
-	//user.drop_item(src.loc)
-	return
-
+	return ..()
 
 /obj/structure/railing/ex_act(severity)
 	switch(severity)
@@ -262,27 +289,30 @@ obj/structure/railing/New()
 		else
 	return
 
-/obj/structure/railing/attack_hand(mob/user as mob)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.a_intent == "disarm")
-			if(prob(70))
-				visible_message("<span class='notice'>[user] climbs on the [src].</span>")
-				if(user.loc == src.loc)
-					switch(dir)
-						if(SOUTH)
-							user.y--
-						if(NORTH)
-							user.y++
-						if(WEST)
-							user.x--
-						if(EAST)
-							user.x++
-				else	H.loc = src.loc
-					return 1
-			else
-				sleep(5)
-				visible_message("<span class='warning'>[user] slipped off the edge of the [src].</span>")
-				usr.weakened += 3
+/obj/structure/railing/do_climb(var/mob/living/user)
+	if(!can_climb(user))
+		return
 
-/obj/structure/railing/
+	usr.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
+	climbers |= user
+
+	if(!do_after(user,(issmall(user) ? 20 : 34)))
+		climbers -= user
+		return
+
+	if(!can_climb(user, post_climb_check=1))
+		climbers -= user
+		return
+
+	if(get_step(src, src.dir) == "turf/simulated/wall/")
+		climbers -= user
+		return
+
+	if(get_turf(user) == get_turf(src))
+		usr.forceMove(get_step(src, src.dir))
+	else
+		usr.forceMove(get_turf(src))
+
+	usr.visible_message("<span class='warning'>[user] climbed over \the [src]!</span>")
+	if(!anchored)	take_damage(maxhealth) // Fatboy
+	climbers -= user

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -56,6 +56,7 @@
 	recipes += new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60)
 	recipes += new/datum/stack_recipe("computer frame", /obj/structure/computerframe, 5, time = 25, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("wall girders", /obj/structure/girder, 2, time = 50, one_per_turf = 1, on_floor = 1)
+	recipes += new/datum/stack_recipe("railing", /obj/structure/railing, 2, time = 50, one_per_turf = 0, on_floor = 1)
 	recipes += new/datum/stack_recipe("machine frame", /obj/machinery/constructable_frame/machine_frame, 5, time = 25, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe("turret frame", /obj/machinery/porta_turret_construct, 5, time = 25, one_per_turf = 1, on_floor = 1)
 	recipes += new/datum/stack_recipe_list("airlock assemblies", list( \


### PR DESCRIPTION
Переработка перил по иссую #457. Теперь они должны работать как надо и красиво.
Что сделанно:
- [x] Через перила можно перелазить, как через столы. Если перелезть в опенспейс - падение на этаж ниже.
- [x] Можно перекидывать космонавтиков через перила. 
- [x] Перила можно сломать лицом космонавта, можно сломать любыми предметами, дропнутся родсы.
- [x] Так же их можно разобрать (2 куска метала на выходе), отвинтить, починить, создать (за те же 2 куска метала).
- [x] Добавлен верб flip() для того, чтобы была возможность замен перил в труднодоступных местах.
