### PR TITLE
Fix #554. Readable names in stripping menu.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -229,7 +229,7 @@
 	user.set_machine(src)
 	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
 
-	var/datum/hud/human/HUDdatum = global.HUDdatums[H.defaultHUD]
+	var/datum/hud/human/HUDdatum = global.HUDdatums[src.defaultHUD]
 
 	for(var/entry in species.hud.gear)
 		var/slot = species.hud.gear[entry]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -229,12 +229,15 @@
 	user.set_machine(src)
 	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
 
+	var/datum/hud/human/HUDdatum = global.HUDdatums[H.defaultHUD]
+
 	for(var/entry in species.hud.gear)
 		var/slot = species.hud.gear[entry]
 		if(slot in list(slot_l_store, slot_r_store))
 			continue
+		var/entry_name = HUDdatum.slot_data[entry]["name"]
 		var/obj/item/thing_in_slot = get_equipped_item(slot)
-		dat += "<BR><B>[entry]:</b> <a href='?src=\ref[src];item=[slot]'>[istype(thing_in_slot) ? thing_in_slot : "nothing"]</a>"
+		dat += "<BR><B>[entry_name]:</b> <a href='?src=\ref[src];item=[slot]'>[istype(thing_in_slot) ? thing_in_slot : "nothing"]</a>"
 
 	dat += "<BR><HR>"
 


### PR DESCRIPTION
Не уверен, что все как надо. По идее, должно работать.
Человекочитаемые имена для слотов в меню раздевания вместо технических.