### PR TITLE
click macro exploit fixes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -11,6 +11,7 @@
 // END_PREFERENCES
 // BEGIN_INCLUDE
 #include "code\_macros.dm"
+#include "code\client_macros.dm"
 #include "code\global.dm"
 #include "code\hub.dm"
 #include "code\names.dm"

--- a/code/client_macros.dm
+++ b/code/client_macros.dm
@@ -1,0 +1,39 @@
+/client
+	control_freak = CONTROL_FREAK_ALL | CONTROL_FREAK_MACROS | CONTROL_FREAK_SKIN
+
+var/list/registered_macros_by_ckey_
+
+// Disables click and double-click macros, as per http://www.byond.com/forum/?post=2219001
+/mob/verb/DisableClick(argu = null as anything, sec = "" as text,number1 = 0 as num, number2 = 0 as num)
+	set name = ".click"
+	set category = null
+	log_macro(ckey, ".click")
+
+/mob/verb/DisableDblClick(argu = null as anything, sec = "" as text, number1 = 0 as num, number2 = 0 as num)
+	set name = ".dblclick"
+	set category = null
+	log_macro(ckey, ".dblclick")
+
+/proc/log_macro(var/ckey, var/macro)
+	usr << "The [macro] macro is disabled due to potential exploits."
+	if(is_macro_use_registered(ckey, macro))
+		return
+	register_macro_use(ckey, macro)
+	log_and_message_admins("attempted to use the disabled [macro] macro.")
+
+/proc/get_registered_macros()
+	if(!registered_macros_by_ckey_)
+		registered_macros_by_ckey_ = list()
+	return registered_macros_by_ckey_
+
+/proc/is_macro_use_registered(var/ckey, var/macro)
+	var/list/registered_macros = get_registered_macros()[ckey]
+	return registered_macros && (macro in registered_macros)
+
+/proc/register_macro_use(var/ckey, var/macro)
+	var/list/registered_macros_by_ckey = get_registered_macros()
+	var/list/registered_macros = registered_macros_by_ckey[ckey]
+	if(!registered_macros)
+		registered_macros = list()
+		registered_macros_by_ckey[ckey] = registered_macros
+	registered_macros |= macro


### PR DESCRIPTION
Там всплыл неприятный эксплоит, позволявший абузить макрокоманды.

Оригинальный тред: http://www.byond.com/forum/?post=2219001
https://github.com/Baystation12/Baystation12/pull/16441
https://github.com/Baystation12/Baystation12/pull/16444
https://github.com/Baystation12/Baystation12/pull/16461

https://github.com/tgstation/tgstation/pull/24543
Моё уважение, ParadiseSS13