### PR TITLE
Player Panel Update

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -61,20 +61,15 @@ proc/admin_notice(var/message, var/rights)
 		[admin_jump_link(M, src)]\] <br><br>"}
 
 	if(M.client)
-		body += {"<b>Client Online</b><br/>
-			<b>ckey</b> = [M.client.ckey]<br>
-			<b>Client Age</b> = [M.client.player_age] days<br>
-			<b>CID Related Accounts</b> = [M.client.related_accounts_cid]<br>
-			<b>IP Related Accounts</b> = [M.client.related_accounts_ip]<br>
-			<b>Client Gender</b> = [M.client.gender]<br>
+		body += {"<b>Client Age On Server</b> = [M.client.player_age] days<br>
 			<b>IP</b> = [M.client.address]<br>
 			<b>CID</b> = [M.client.computer_id]<br>
+			<b>IP Related Accounts</b> = [M.client.related_accounts_ip]<br>
+			<b>CID Related Accounts</b> = [M.client.related_accounts_cid]<br>
 			<b>Mob type</b> = [M.type]<br>
 			<b>Inactivity time:</b> [M.client ? "[M.client.inactivity/600] minutes" : "Logged out"]<br><br>"}
 	else
-		body += {"<b>Client Offline</b><br/>
-			<b>ckey</b> = [M.ckey]<br>
-			<b>IP</b> = [M.lastKnownIP]<br>
+		body += {"b>IP</b> = [M.lastKnownIP]<br>
 			<b>CID</b> = [M.computer_id]<br>
 			<b>Mob type</b> = [M.type]<br>
 			<b>Inactivity time:</b> [M.client ? "[M.client.inactivity/600] minutes" : "Logged out"]<br><br>"}

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -58,9 +58,28 @@ proc/admin_notice(var/message, var/rights)
 		<a href='?src=\ref[src];traitor=\ref[M]'>TP</a> -
 		<a href='?src=\ref[usr];priv_msg=\ref[M]'>PM</a> -
 		<a href='?src=\ref[src];subtlemessage=\ref[M]'>SM</a> -
-		[admin_jump_link(M, src)]\] <br>
-		<b>Mob type</b> = [M.type]<br><br>
-		<A href='?src=\ref[src];boot2=\ref[M]'>Kick</A> |
+		[admin_jump_link(M, src)]\] <br><br>"}
+
+	if(M.client)
+		body += {"<b>Client Online</b><br/>
+			<b>ckey</b> = [M.client.ckey]<br>
+			<b>Client Age</b> = [M.client.player_age] days<br>
+			<b>CID Related Accounts</b> = [M.client.related_accounts_cid]<br>
+			<b>IP Related Accounts</b> = [M.client.related_accounts_ip]<br>
+			<b>Client Gender</b> = [M.client.gender]<br>
+			<b>IP</b> = [M.client.address]<br>
+			<b>CID</b> = [M.client.computer_id]<br>
+			<b>Mob type</b> = [M.type]<br>
+			<b>Inactivity time:</b> [M.client ? "[M.client.inactivity/600] minutes" : "Logged out"]<br><br>"}
+	else
+		body += {"<b>Client Offline</b><br/>
+			<b>ckey</b> = [M.ckey]<br>
+			<b>IP</b> = [M.lastKnownIP]<br>
+			<b>CID</b> = [M.computer_id]<br>
+			<b>Mob type</b> = [M.type]<br>
+			<b>Inactivity time:</b> [M.client ? "[M.client.inactivity/600] minutes" : "Logged out"]<br><br>"}
+
+	body += {"<A href='?src=\ref[src];boot2=\ref[M]'>Kick</A> |
 		<A href='?_src_=holder;warn=[M.ckey]'>Warn</A> |
 		<A href='?src=\ref[src];newban=\ref[M]'>Ban</A> |
 		<A href='?src=\ref[src];jobban2=\ref[M]'>Jobban</A> |
@@ -68,7 +87,8 @@ proc/admin_notice(var/message, var/rights)
 	"}
 
 	if(M.client)
-		body += "| <A HREF='?src=\ref[src];sendtoprison=\ref[M]'>Prison</A> | "
+		body += {"| <A HREF='?src=\ref[src];sendtoprison=\ref[M]'>Prison</A> |
+		<A href='?_src_=holder;sendbacktolobby=\ref[M]'>Send back to Lobby</A>"}
 		var/muted = M.client.prefs.muted
 		body += {"<br><b>Mute: </b>
 			\[<A href='?src=\ref[src];mute=\ref[M];mute_type=[MUTE_IC]'><font color='[(muted & MUTE_IC)?"red":"blue"]'>IC</font></a> |

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -90,7 +90,8 @@ var/list/admin_verbs_admin = list(
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
-	/client/proc/jobbans
+	/client/proc/jobbans,
+	/client/proc/DB_ban_panel
 	)
 var/list/admin_verbs_sounds = list(
 	/client/proc/play_local_sound,

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -989,6 +989,30 @@
 		log_admin("[key_name(usr)] sent [key_name(M)] to the prison station.")
 		message_admins("\blue [key_name_admin(usr)] sent [key_name_admin(M)] to the prison station.", 1)
 
+	else if(href_list["sendbacktolobby"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/mob/M = locate(href_list["sendbacktolobby"])
+
+		if(!isobserver(M))
+			usr << "<span class='notice'>You can only send ghost players back to the Lobby.</span>"
+			return
+
+		if(!M.client)
+			usr << "<span class='warning'>[M] doesn't seem to have an active client.</span>"
+			return
+
+		if(alert(usr, "Send [key_name(M)] back to Lobby?", "Message", "Yes", "No") != "Yes")
+			return
+
+		log_admin("[key_name(usr)] has sent [key_name(M)] back to the Lobby.")
+		message_admins("[key_name(usr)] has sent [key_name(M)] back to the Lobby.")
+
+		var/mob/new_player/NP = new()
+		NP.ckey = M.ckey
+		qdel(M)
+
 	else if(href_list["tdome1"])
 		if(!check_rights(R_FUN))	return
 


### PR DESCRIPTION
### Changes:
- Now admins can check some information, like IP, CID and client age.
- Also, admins can press special button "Send back to lobby". This will quickly send selected ghost to lobby.
- Like a bonus, i adding a new ban panel in ban permission verbs, because with this panel, admins can not just baning/unbaning, they can check existing bans!

### Screenshot:
<details>
  <summary>Click to expand</summary>
  
![2b1c79ba-0433-11e7-8761-aaee15d17c7f](https://cloud.githubusercontent.com/assets/17644501/23712466/0dfdd580-0434-11e7-9271-766438065b4d.png)

</details>