### PR TITLE
Fix airlock opening animating icon if wire panel on it was been opened

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -564,18 +564,16 @@ About the new airlock wires panel:
 		if("opening")
 			if(overlays) overlays.Cut()
 			if(p_open)
-				spawn(2) // The only work around that works. Downside is that the door will be gone for a millisecond.
-					flick("o_door_opening", src)  //can not use flick due to BYOND bug updating overlays right before flicking
-					update_icon()
+				flick("o_door_opening", src)  //can not use flick due to BYOND bug updating overlays right before flicking
+				update_icon()
 			else
 				flick("door_opening", src)//[stat ? "_stat":]
 				update_icon()
 		if("closing")
 			if(overlays) overlays.Cut()
 			if(p_open)
-				spawn(2)
-					flick("o_door_closing", src)
-					update_icon()
+				flick("o_door_closing", src)
+				update_icon()
 			else
 				flick("door_closing", src)
 				update_icon()


### PR DESCRIPTION
### Changing:
 - Fixed all airlocks, Whose animating icons when airlocks opening with open wire panel looks little bit strange. Closes #631 